### PR TITLE
Refactor JSON structure for board configuration

### DIFF
--- a/docs/src/examples/json/5a-75b_v8.0_i12o14p6s6e6.json
+++ b/docs/src/examples/json/5a-75b_v8.0_i12o14p6s6e6.json
@@ -1,117 +1,270 @@
 {
-    "board_name": "5A-75B:V8.0",
-    "board_type": "5A-75B v8.0",
-    "clock_frequency": 40000000,
-    "connection": {
-        "connection_type": "etherbone",
-        "tx_delay": 0,
-        "ip_address": "10.0.0.10",
-        "mac_address": "0x10e2d5000000"
-    },
-    "watchdog": {
-        "pin":"j1:8"
-    },
-    "modules": [
+  "board_name": "5A-75B:V8.0",
+  "board_type": "5A-75B v8.0",
+  "clock_frequency": 40000000,
+  "connection": {
+    "connection_type": "etherbone",
+    "tx_delay": 0,
+    "ip_address": "10.0.0.10",
+    "mac_address": "0x10e2d5000000"
+  },
+  "watchdog": {
+    "pin": "j1:8"
+  },
+  "modules": [
+    {
+      "module_type": "gpio",
+      "instances": [
         {
-            "module_type": "gpio",
-            "instances": [
-                {"direction": "out", "pin":"j1:9",  "name":"j1:10"},
-                {"direction": "out", "pin":"j1:10", "name":"j1:11"},
-                {"direction": "out", "pin":"j1:11", "name":"j1:12"},
-                {"direction": "out", "pin":"j1:12", "name":"j1:13"},
-                {"direction": "out", "pin":"j1:13", "name":"j1:14"},
-                {"direction": "out", "pin":"j1:14", "name":"j1:15"},
-                {"direction": "in",  "pin":"j1:0",  "name":"j1:1" },
-                {"direction": "in",  "pin":"j1:1",  "name":"j1:2" },
-                {"direction": "in",  "pin":"j1:2",  "name":"j1:3" },
-                {"direction": "in",  "pin":"j1:4",  "name":"j1:5" },
-                {"direction": "in",  "pin":"j1:5",  "name":"j1:6" },
-                {"direction": "in",  "pin":"j1:6",  "name":"j1:7" },
-                {"direction": "in",  "pin":"j2:0",  "name":"j2:1" },
-                {"direction": "in",  "pin":"j2:1",  "name":"j2:2" },
-                {"direction": "in",  "pin":"j2:2",  "name":"j2:3" },
-                {"direction": "in",  "pin":"j2:4",  "name":"j2:5" },
-                {"direction": "in",  "pin":"j2:5",  "name":"j2:6" },
-                {"direction": "in",  "pin":"j2:6",  "name":"j2:7" },
-                {"direction": "out", "pin":"j5:0",  "name":"j5:1" },
-                {"direction": "out", "pin":"j5:1",  "name":"j5:2" },
-                {"direction": "out", "pin":"j5:2",  "name":"j5:3" },
-                {"direction": "out", "pin":"j5:4",  "name":"j5:5" },
-                {"direction": "out", "pin":"j5:5",  "name":"j5:6" },
-                {"direction": "out", "pin":"j5:6",  "name":"j5:7" }
-            ]
-        }, {
-            "module_type": "pwm",
-            "instances": [
-                {"pin":"j6:0", "name":"j6:1"},
-                {"pin":"j6:1", "name":"j6:2"},
-                {"pin":"j6:2", "name":"j6:3"},
-                {"pin":"j6:4", "name":"j6:5"},
-                {"pin":"j6:5", "name":"j6:6"},
-                {"pin":"j6:6", "name":"j6:7"}
-            ]
-        }, {
-            "module_type": "encoder",
-            "instances": [
-                {"pin_A":"j3:0", "pin_B":"j3:1"},
-                {"pin_A":"j3:2", "pin_B":"j3:4"},
-                {"pin_A":"j3:5", "pin_B":"j3:6"},
-                {"pin_A":"j4:0", "pin_B":"j4:1"},
-                {"pin_A":"j4:2", "pin_B":"j4:4"},
-                {"pin_A":"j4:5", "pin_B":"j4:6"}
-            ]
-        }, {
-            "module_type": "stepgen",
-            "instances": [
-                {
-                    "pins" : {
-                        "stepgen_type": "step_dir",
-                        "step_pin": "j7:0",
-                        "dir_pin": "j7:1"
-                    },
-                    "soft_stop": true
-                },
-                {
-                    "pins" : {
-                        "stepgen_type": "step_dir",
-                        "step_pin": "j7:2",
-                        "dir_pin": "j7:4"
-                    },
-                    "soft_stop": true
-                },
-                {
-                    "pins" : {
-                        "stepgen_type": "step_dir",
-                        "step_pin": "j7:5",
-                        "dir_pin": "j7:6"
-                    },
-                    "soft_stop": true
-                },
-                {
-                    "pins" : {
-                        "stepgen_type": "step_dir",
-                        "step_pin": "j8:0",
-                        "dir_pin": "j8:1"
-                    },
-                    "soft_stop": true
-                },
-                {
-                    "pins" : {
-                        "stepgen_type": "step_dir",
-                        "step_pin": "j8:2",
-                        "dir_pin": "j8:4"
-                    },
-                    "soft_stop": true
-                },
-                {
-                    "pins" : {
-                        "stepgen_type": "step_dir",
-                        "step_pin": "j8:5",
-                        "dir_pin": "j8:6"
-                    },
-                    "soft_stop": true
-                }
-            ]
+          "direction": "out",
+          "pin": "j1:9",
+          "name": "j1:10"
+        },
+        {
+          "direction": "out",
+          "pin": "j1:10",
+          "name": "j1:11"
+        },
+        {
+          "direction": "out",
+          "pin": "j1:11",
+          "name": "j1:12"
+        },
+        {
+          "direction": "out",
+          "pin": "j1:12",
+          "name": "j1:13"
+        },
+        {
+          "direction": "out",
+          "pin": "j1:13",
+          "name": "j1:14"
+        },
+        {
+          "direction": "out",
+          "pin": "j1:14",
+          "name": "j1:15"
+        },
+        {
+          "direction": "in",
+          "pin": "j1:0",
+          "name": "j1:1"
+        },
+        {
+          "direction": "in",
+          "pin": "j1:1",
+          "name": "j1:2"
+        },
+        {
+          "direction": "in",
+          "pin": "j1:2",
+          "name": "j1:3"
+        },
+        {
+          "direction": "in",
+          "pin": "j1:4",
+          "name": "j1:5"
+        },
+        {
+          "direction": "in",
+          "pin": "j1:5",
+          "name": "j1:6"
+        },
+        {
+          "direction": "in",
+          "pin": "j1:6",
+          "name": "j1:7"
+        },
+        {
+          "direction": "in",
+          "pin": "j2:0",
+          "name": "j2:1"
+        },
+        {
+          "direction": "in",
+          "pin": "j2:1",
+          "name": "j2:2"
+        },
+        {
+          "direction": "in",
+          "pin": "j2:2",
+          "name": "j2:3"
+        },
+        {
+          "direction": "in",
+          "pin": "j2:4",
+          "name": "j2:5"
+        },
+        {
+          "direction": "in",
+          "pin": "j2:5",
+          "name": "j2:6"
+        },
+        {
+          "direction": "in",
+          "pin": "j2:6",
+          "name": "j2:7"
+        },
+        {
+          "direction": "out",
+          "pin": "j5:0",
+          "name": "j5:1"
+        },
+        {
+          "direction": "out",
+          "pin": "j5:1",
+          "name": "j5:2"
+        },
+        {
+          "direction": "out",
+          "pin": "j5:2",
+          "name": "j5:3"
+        },
+        {
+          "direction": "out",
+          "pin": "j5:4",
+          "name": "j5:5"
+        },
+        {
+          "direction": "out",
+          "pin": "j5:5",
+          "name": "j5:6"
+        },
+        {
+          "direction": "out",
+          "pin": "j5:6",
+          "name": "j5:7"
         }
-    ]
+      ]
+    },
+    {
+      "module_type": "pwm",
+      "instances": [
+        {
+          "pins": {
+            "pwm": "j6:0",
+            "name": "j6:1",
+            "output_type": "single"
+          }
+        },
+        {
+          "pins": {
+            "pwm": "j6:1",
+            "name": "j6:2",
+            "output_type": "single"
+          }
+        },
+        {
+          "pins": {
+            "pwm": "j6:2",
+            "name": "j6:3",
+            "output_type": "single"
+          }
+        },
+        {
+          "pins": {
+            "pwm": "j6:4",
+            "name": "j6:5",
+            "output_type": "single"
+          }
+        },
+        {
+          "pins": {
+            "pwm": "j6:5",
+            "name": "j6:6",
+            "output_type": "single"
+          }
+        },
+        {
+          "pins": {
+            "pwm": "j6:6",
+            "name": "j6:7",
+            "output_type": "single"
+          }
+        }
+      ]
+    },
+    {
+      "module_type": "encoder",
+      "instances": [
+        {
+          "pin_A": "j3:0",
+          "pin_B": "j3:1"
+        },
+        {
+          "pin_A": "j3:2",
+          "pin_B": "j3:4"
+        },
+        {
+          "pin_A": "j3:5",
+          "pin_B": "j3:6"
+        },
+        {
+          "pin_A": "j4:0",
+          "pin_B": "j4:1"
+        },
+        {
+          "pin_A": "j4:2",
+          "pin_B": "j4:4"
+        },
+        {
+          "pin_A": "j4:5",
+          "pin_B": "j4:6"
+        }
+      ]
+    },
+    {
+      "module_type": "stepgen",
+      "instances": [
+        {
+          "pins": {
+            "stepgen_type": "step_dir",
+            "step_pin": "j7:0",
+            "dir_pin": "j7:1"
+          },
+          "soft_stop": true
+        },
+        {
+          "pins": {
+            "stepgen_type": "step_dir",
+            "step_pin": "j7:2",
+            "dir_pin": "j7:4"
+          },
+          "soft_stop": true
+        },
+        {
+          "pins": {
+            "stepgen_type": "step_dir",
+            "step_pin": "j7:5",
+            "dir_pin": "j7:6"
+          },
+          "soft_stop": true
+        },
+        {
+          "pins": {
+            "stepgen_type": "step_dir",
+            "step_pin": "j8:0",
+            "dir_pin": "j8:1"
+          },
+          "soft_stop": true
+        },
+        {
+          "pins": {
+            "stepgen_type": "step_dir",
+            "step_pin": "j8:2",
+            "dir_pin": "j8:4"
+          },
+          "soft_stop": true
+        },
+        {
+          "pins": {
+            "stepgen_type": "step_dir",
+            "step_pin": "j8:5",
+            "dir_pin": "j8:6"
+          },
+          "soft_stop": true
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The PWM Instance requires a pins Object in the latest LiteXCNC Version, otherwise build_firmware throws a stack.